### PR TITLE
ftools not found in ruby 1.9

### DIFF
--- a/lib/ralf.rb
+++ b/lib/ralf.rb
@@ -1,7 +1,7 @@
 require 'rubygems'
 require 'right_aws'
 require 'logmerge'
-require 'ftools'
+require 'fileutils'
 require 'ralf/config'
 require 'ralf/bucket'
 require 'chronic'
@@ -84,7 +84,7 @@ class Ralf
       merged_log =  output_log + ".alf"
 
       # create directory for output file
-      File.makedirs(File.dirname(merged_log))
+      FileUtils.mkdir_p(File.dirname(merged_log))
 
       # merge the log files
       Ralf.merge(merged_log, log_files)
@@ -112,7 +112,7 @@ class Ralf
   
   # Download log files for +bucket+ and +date+ to +dir+.
   def self.download_logs(bucket, date, dir)
-    File.makedirs(dir)
+    FileUtils.mkdir_p(dir)
 
     # iterate over the available log files, saving them to disk and 
     log_files = []


### PR DESCRIPTION
Just patched the gem to work with ruby 1.9+ replacing Ftools for FileUtils.

Notice: Can't test because of this https://github.com/kjwierenga/ralf/blob/master/Rakefile#L33

BTW: Really nice util. Keep up the good work!
